### PR TITLE
Add trace context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Observe the logs
 
 Note that not all log entries will immediately be written to the `otlp-logs.log` file. The collector will flush to the disk eventually. The flush will be forced if the collector receives a kill signal.
 
+## Examples
+[HTTP Server with trace context propagation](./examples/trace-context)
+
 ## Options
 
 When using the transport, the following options can be used:

--- a/examples/trace-context/README.md
+++ b/examples/trace-context/README.md
@@ -1,0 +1,23 @@
+#HTTP Server with trace context propagation
+
+## Running the example
+
+1. Run the [docker compose file](/docker-compose.yaml) in the root of the repo, which will boot the OTLP collector.
+`docker compose up`
+
+2. Run the http server by [preloading](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/#run-the-instrumented-app) the instrumentation code.
+```
+node -r "./trace-instrumentation.js" http-server.js
+```
+
+3. Access the app at [http://localhost:8080](http://localhost:8080)
+
+The request handler function in http-server will create a log entry. Since pino is instrumented with [@opentelemetry/instrumentation-pino](https://www.npmjs.com/package/@opentelemetry/instrumentation-pino) in `trace-instrumentation.js`, it will also add the span context values as attributes [(`trace_id`, `span_id`, `trace_flags`)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#fields-added-to-pino-log-objects).
+
+[pino-opentelemetry-transport](https://www.npmjs.com/package/pino-opentelemetry-transport) will read those attributes and add them to the current context. The resulting LogRecord will have those fields populated. Fields `trace_id`, `span_id`, `trace_flags` will not be visible in the LogRecord attributes.
+
+
+Observe the logs with:
+
+```tail -f /tmp/test-logs/otlp-logs.log```
+

--- a/examples/trace-context/README.md
+++ b/examples/trace-context/README.md
@@ -1,4 +1,4 @@
-#HTTP Server with trace context propagation
+# HTTP Server with trace context propagation
 
 ## Running the example
 

--- a/examples/trace-context/README.md
+++ b/examples/trace-context/README.md
@@ -2,7 +2,7 @@
 
 ## Running the example
 
-1. Run the [docker compose file](/docker-compose.yaml) in the root of the repo, which will boot the OTLP collector.
+1. Run the [docker compose file](/docker-compose.yaml) in the root of the repo, which will boot the OTLP collector:
 `docker compose up`
 
 2. Run the http server by [preloading](https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/#run-the-instrumented-app) the instrumentation code.
@@ -11,6 +11,9 @@ node -r "./trace-instrumentation.js" http-server.js
 ```
 
 3. Access the app at [http://localhost:8080](http://localhost:8080)
+
+
+### Explanation
 
 The request handler function in http-server will create a log entry. Since pino is instrumented with [@opentelemetry/instrumentation-pino](https://www.npmjs.com/package/@opentelemetry/instrumentation-pino) in `trace-instrumentation.js`, it will also add the span context values as attributes [(`trace_id`, `span_id`, `trace_flags`)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#fields-added-to-pino-log-objects).
 

--- a/examples/trace-context/http-server.js
+++ b/examples/trace-context/http-server.js
@@ -1,0 +1,23 @@
+// https://nodejs.dev/en/learn/#an-example-nodejs-application
+const http = require('http')
+const pino = require('pino')
+const path = require('path')
+const transport = pino.transport({
+  target: path.join(__dirname, '..', '..', 'pino-opentelemetry-transport')
+})
+
+const logger = pino(transport)
+
+const hostname = '127.0.0.1'
+const port = 8080
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'text/plain')
+  logger.info({ msg: 'test log', foo: 'bar' })
+  res.end('Hello World\n')
+})
+
+server.listen(port, hostname, () => {
+  logger.info(`Server running at http://${hostname}:${port}/`)
+})

--- a/examples/trace-context/trace-instrumentation.js
+++ b/examples/trace-context/trace-instrumentation.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const process = require('process')
+const opentelemetry = require('@opentelemetry/sdk-node')
+const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
+const { PinoInstrumentation } = require('@opentelemetry/instrumentation-pino')
+const { Resource } = require('@opentelemetry/resources')
+// const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
+const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-node')
+const {
+  SemanticResourceAttributes
+} = require('@opentelemetry/semantic-conventions')
+
+const traceExporter = new ConsoleSpanExporter()
+// const traceExporter = new OTLPTraceExporter()
+
+const instrumentations = [
+  new HttpInstrumentation(),
+  new PinoInstrumentation()
+]
+
+const sdk = new opentelemetry.NodeSDK({
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: 'Pino OpenTelemetry Example'
+  }),
+  traceExporter,
+  instrumentations
+})
+
+sdk.start()
+
+process.on('SIGTERM', () => {
+  sdk
+    .shutdown()
+    .then(() => console.log('Tracing terminated'))
+    .catch(error => console.log('Error terminating tracing', error))
+    .finally(() => process.exit(0))
+})

--- a/examples/trace-context/trace-instrumentation.js
+++ b/examples/trace-context/trace-instrumentation.js
@@ -5,14 +5,12 @@ const opentelemetry = require('@opentelemetry/sdk-node')
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
 const { PinoInstrumentation } = require('@opentelemetry/instrumentation-pino')
 const { Resource } = require('@opentelemetry/resources')
-// const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
 const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-node')
 const {
   SemanticResourceAttributes
 } = require('@opentelemetry/semantic-conventions')
 
 const traceExporter = new ConsoleSpanExporter()
-// const traceExporter = new OTLPTraceExporter()
 
 const instrumentations = [
   new HttpInstrumentation(),

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "types": "./pino-opentelemetry-transport.d.ts",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
+    "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/instrumentation-http": "^0.41.2",
+    "@opentelemetry/instrumentation-pino": "^0.34.1",
+    "@opentelemetry/sdk-node": "^0.41.2",
     "@types/node": "^17.0.0",
     "pino": "^8.14.1",
     "require-inject": "^1.4.4",

--- a/test/otlp-logger.test.js
+++ b/test/otlp-logger.test.js
@@ -36,9 +36,17 @@ test('otlp logger logs a record in log exporter and maps all log levels correctl
     hostname: 'test-hostname'
   }
 
+  const testTraceId = '12345678901234567890123456789012'
+  const testSpanId = '1234567890123456'
+  const testTraceFlags = '01'
+
   logger.emit({
     ...testLogEntryBase,
-    level: 10
+    level: 10,
+    trace_id: testTraceId,
+    span_id: testSpanId,
+    trace_flags: testTraceFlags,
+    testAttribute: 'test'
   })
   logger.emit({
     ...testLogEntryBase,
@@ -84,6 +92,15 @@ test('otlp logger logs a record in log exporter and maps all log levels correctl
   match(records[0].instrumentationScope, {
     name: 'test-logger',
     version: '1.0.0'
+  })
+  match(records[0].spanContext, {
+    traceId: testTraceId,
+    spanId: testSpanId,
+    traceFlags: testTraceFlags,
+    isRemote: true
+  })
+  same(records[0].attributes, {
+    testAttribute: 'test'
   })
 
   match(records[1].severityNumber, 5)

--- a/test/pino-opentelemetry-transport.test.js
+++ b/test/pino-opentelemetry-transport.test.js
@@ -16,8 +16,12 @@ before(async () => {
   const composeFilePath = join(__dirname, '..')
   const composeFile = 'docker-compose.yaml'
 
-  const dockerComposeEnv = new DockerComposeEnvironment(composeFilePath, composeFile).withWaitStrategy(
-    'otel-collector-1', Wait.forLogMessage('Everything is ready')
+  const dockerComposeEnv = new DockerComposeEnvironment(
+    composeFilePath,
+    composeFile
+  ).withWaitStrategy(
+    'otel-collector-1',
+    Wait.forLogMessage('Everything is ready')
   )
 
   await dockerComposeEnv.up()
@@ -93,9 +97,18 @@ test('translate Pino log format to Open Telemetry data format for each log level
     version: 'test-service-version'
   }
 
+  const testTraceId = '12345678901234567890123456789012'
+  const testSpanId = '1234567890123456'
+  const testTraceFlags = '01'
+
   const extra = {
     foo: 'bar',
-    baz: 'qux'
+    baz: 'qux',
+    /* eslint-disable camelcase */
+    trace_id: testTraceId,
+    span_id: testSpanId,
+    trace_flags: testTraceFlags
+    /* eslint-enable camelcase */
   }
 
   logger.trace(extra, 'test trace')
@@ -248,8 +261,8 @@ test('translate Pino log format to Open Telemetry data format for each log level
                   severityNumber: 1,
                   severityText: 'TRACE',
                   body: { stringValue: 'test trace' },
-                  traceId: '',
-                  spanId: '',
+                  traceId: testTraceId,
+                  spanId: testSpanId,
                   attributes: [
                     { key: 'foo', value: { stringValue: 'bar' } },
                     { key: 'baz', value: { stringValue: 'qux' } }


### PR DESCRIPTION
If pino is instrumented with [@opentelemetry/instrumentation-pino](https://www.npmjs.com/package/@opentelemetry/instrumentation-pino), it will also add the span context values as attributes [(`trace_id`, `span_id`, `trace_flags`)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#fields-added-to-pino-log-objects).

This PR makes the transport read those attributes and add them to the current context. The resulting LogRecord will have those fields populated. Fields `trace_id`, `span_id`,`trace_flags` will not be visible in the LogRecord attributes.

Fix #16 #17 